### PR TITLE
add missing #include <unistd.h>

### DIFF
--- a/exec_with_namespace.cpp
+++ b/exec_with_namespace.cpp
@@ -1,3 +1,4 @@
+#include <unistd.h>
 #include <sys/mount.h>
 #include <sys/stat.h>
 #include <cassert>


### PR DESCRIPTION
This is required to build on RHEL7, and harmless for other Linuxes.
